### PR TITLE
mx23: fix VDDM drop and boot instabilities

### DIFF
--- a/arch/arm/cpu/arm926ejs/mxs/spl_mem_init.c
+++ b/arch/arm/cpu/arm926ejs/mxs/spl_mem_init.c
@@ -275,8 +275,6 @@ static void mx23_mem_init(void)
 	 */
 	mxs_reset_block((struct mxs_register_32 *)MXS_EMI_BASE);
 
-	mx23_mem_setup_vddmem();
-
 	/*
 	 * Configure the DRAM registers
 	 */
@@ -343,6 +341,12 @@ static void mx28_mem_init(void)
 void mxs_mem_init(void)
 {
 	early_delay(11000);
+
+#if defined(CONFIG_MX23)
+	//disable memory current limiter (before accessing memory, see datasheet page 1307 - ENABLE_ILIMIT)
+	//otherwise the VDDM will drop to 2V and can cause reboot loops
+	mx23_mem_setup_vddmem();
+#endif
 
 	mxs_mem_init_clock();
 


### PR DESCRIPTION
disabling the current limit too late, will cause the VDDM to drop to ~2V @ boot and causes reboot loops on 2%-5% of the cpu's with production date >= 2017 when the cpu's are cold.

VDDM drop issues (without patch):
![imx23_uboot_VDDM_drop_issue](https://github.com/popy2k14/u-boot/assets/6324597/048cd908-547e-4e1d-8245-eb4196298a83)

VDDM drop issues fixed (with patch):
![imx23_uboot_VDDM_drop_issue_solved](https://github.com/popy2k14/u-boot/assets/6324597/a538491f-b3fe-496e-9a17-a53a1884732e)

CPU from 2015, boot's when it's cold without patch:
![IMX23_2015_batch](https://github.com/popy2k14/u-boot/assets/6324597/a51f7a16-0434-4593-9645-132f593b5cdf)

CPU from 2019, sometimes bootloop's when it's cold without patch:
![IMX23_2019_batch](https://github.com/popy2k14/u-boot/assets/6324597/f4c14f16-0ede-4bfb-9f33-7b88c442c6f2)


Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
